### PR TITLE
Fix name of msi_safe reader in Sentinel 2 example

### DIFF
--- a/satpy/Sentinel 2 MSI true color.ipynb
+++ b/satpy/Sentinel 2 MSI true color.ipynb
@@ -25,7 +25,7 @@
     "from satpy import Scene, find_files_and_readers\n",
     "\n",
     "files = find_files_and_readers(base_dir=\"/home/a000680/data/Sentinel-2/\",\n",
-    "                               reader='safe_msi')\n",
+    "                               reader='msi_safe')\n",
     "scn = Scene(filenames=files)"
    ]
   },


### PR DESCRIPTION
Addresses issue in #26