### PR TITLE
Fix deprecated use of combine_attrs for combine_metadata

### DIFF
--- a/satpy/hrit_msg_tutorial.ipynb
+++ b/satpy/hrit_msg_tutorial.ipynb
@@ -246,9 +246,9 @@
     }
    ],
    "source": [
-    "from satpy.dataset import combine_attrs\n",
+    "from satpy.dataset import combine_metadata\n",
     "ndvi = (scn[0.8] - scn[0.6]) / (scn[0.8] + scn[0.6])\n",
-    "ndvi.attrs = combine_attrs(scn[0.8], scn[0.6])\n",
+    "ndvi.attrs = combine_metadata(scn[0.8], scn[0.6])\n",
     "scn['ndvi'] = ndvi\n",
     "scn.show('ndvi')"
    ]


### PR DESCRIPTION
This was brought up on slack by @peters77 and the solution suggested by @pnuu. This is the fix.