### PR TITLE
Cleanup GOES-16 ABI examples

### DIFF
--- a/satpy/GOES-16 ABI - True Color Animation - Hurricane Florence.ipynb
+++ b/satpy/GOES-16 ABI - True Color Animation - Hurricane Florence.ipynb
@@ -6,15 +6,15 @@
    "source": [
     "Dependencies | Version\n",
     "--- | ---\n",
-    "SatPy | 0.9.3\n",
-    "PyResample | 1.10.1\n",
-    "PySpectral | 0.8.2\n",
-    "Trollimage | 1.5.7\n",
-    "PyKdtree | 1.3.1\n",
-    "XArray | 0.10\n",
-    "Dask | 0.18.2\n",
-    "ImageIO | 2.3.0\n",
-    "ffmpeg | 3.4\n",
+    "SatPy | 0.25.1\n",
+    "PyResample | 1.17.0\n",
+    "PySpectral | 0.10.4\n",
+    "Trollimage | 1.14.0\n",
+    "PyKdtree | 1.3.4\n",
+    "XArray | 0.16.1\n",
+    "Dask | 2.30.0\n",
+    "ImageIO | 2.9.0\n",
+    "ffmpeg | 4.3.1\n",
     "\n",
     "\n",
     "# GOES-16 ABI - True Color Animation - Hurricane Florence\n",
@@ -32,52 +32,82 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Number of Scenes:  100\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Platform file /Users/davidh/repos/git/satpy/satpy/etc/platforms.txt not found.\n",
-      "/Users/davidh/anaconda/envs/polar2grid_py36/lib/python3.6/site-packages/dask/local.py:255: RuntimeWarning: invalid value encountered in log10\n",
-      "  return func(*args2)\n",
-      "/Users/davidh/anaconda/envs/polar2grid_py36/lib/python3.6/site-packages/dask/local.py:255: RuntimeWarning: invalid value encountered in log10\n",
-      "  return func(*args2)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 13min 53s, sys: 6min 2s, total: 19min 55s\n",
-      "Wall time: 8min 29s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "import os\n",
+    "import warnings\n",
+    "import logging\n",
     "from satpy import Scene\n",
     "from glob import glob\n",
-    "from satpy.multiscene import MultiScene\n",
+    "from satpy import MultiScene\n",
+    "logging.basicConfig(level=logging.ERROR)  # don't show warnings\n",
+    "warnings.simplefilter('ignore')  # don't show warnings\n",
     "\n",
-    "BASE_DIR = '/data/data/abi/20180911_florence'\n",
-    "all_filenames = [glob(fn.replace('C01', 'C0[123]*')[:len(BASE_DIR) + 50] + '*.nc') for fn in sorted(glob(os.path.join(BASE_DIR, 'OR*-RadM1-*C01*.nc')))]\n",
-    "scenes = [Scene(reader='abi_l1b', filenames=filenames) for filenames in all_filenames]\n",
-    "print(\"Number of Scenes: \", len(scenes))\n",
+    "BASE_DIR = '/data/satellite/abi/20180911_florence_100'\n",
     "\n",
-    "mscn = MultiScene(scenes)\n",
+    "mscn = MultiScene.from_files(glob(os.path.join(BASE_DIR, 'OR*-RadM1*.nc')), reader='abi_l1b')\n",
     "mscn.load(['true_color'])\n",
     "new_mscn = mscn.resample(resampler='native')\n",
-    "new_mscn.save_animation('/tmp/{name}_{start_time:%Y%m%d_%H%M%S}.mp4', fps=5)"
+    "new_mscn.save_animation('{name}_{start_time:%Y%m%d_%H%M%S}.mp4', fps=5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Video\n",
+    "Video('true_color_20180911_130021.mp4', width=480, height=480)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Advanced Usage\n",
+    "\n",
+    "It is also possible to use dask in a multiprocess environment to compute multiple animation frames at once. We do this by first creating a dask `Client` object which will create external dask workers for us. We then pass this client object to `save_animation` along with a `batch_size`. This tells Satpy to compute `16` frames at a time by using the parallel multiprocess workers created by dask. Without this, Satpy will default to computing one frame at a time. Depending on your system, this can cut off minutes of processing time.\n",
+    "\n",
+    "Note: The creation of the `Client` below includes making a dashboard available for viewing tasks as they are worked on by dask."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask.distributed import Client\n",
+    "client = Client()\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "import os\n",
+    "import warnings\n",
+    "import logging\n",
+    "from satpy import Scene\n",
+    "from glob import glob\n",
+    "from satpy import MultiScene\n",
+    "logging.basicConfig(level=logging.ERROR)  # don't show warnings\n",
+    "warnings.simplefilter('ignore')  # don't show warnings\n",
+    "\n",
+    "BASE_DIR = '/data/satellite/abi/20180911_florence_100'\n",
+    "\n",
+    "mscn = MultiScene.from_files(glob(os.path.join(BASE_DIR, 'OR*-RadM1*.nc')), reader='abi_l1b')\n",
+    "mscn.load(['true_color'])\n",
+    "new_mscn = mscn.resample(resampler='native')\n",
+    "new_mscn.save_animation('{name}_{start_time:%Y%m%d_%H%M%S}.mp4', fps=5, batch_size=16, client=client)"
    ]
   },
   {
@@ -104,9 +134,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/satpy/GOES-16 Mosaic.ipynb
+++ b/satpy/GOES-16 Mosaic.ipynb
@@ -4,7 +4,84 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Generate a mosaic of the GOES-16 channels in Satpy and ImageMagick"
+    "# Generate a mosaic of the GOES-16 ABI channels with Satpy and ImageMagick"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This example shows the basic functionality of reading GOES-16 ABI data and creating a PNG grayscale image for each of the 16 channels. The `montage` command line utility from `ImageMagick` is then used to join the individual images in to one image. In this first cell we do all of this using data from Amazon Web Services (AWS) from the S3 bucket created by NOAA.\n",
+    "\n",
+    "We use the feature of the `fsspec` library called `simplecache` to store files locally. This makes sure that any repeated access to the same files will be fast and use the local cache. In the below code, accessing the remote data the first time and processing it with Satpy will take about 4 minutes depending on your network connection and your local system's resources. Running the same cell again will use the cache and take around 1 minute and 45 seconds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "import glob\n",
+    "from satpy import Scene\n",
+    "from satpy.readers import FSFile\n",
+    "import fsspec\n",
+    "\n",
+    "# Access data from AWS S3 to be read by Satpy\n",
+    "filename = 'noaa-goes16/ABI-L1b-RadF/2019/001/17/*_G16_s201900117003*'\n",
+    "the_files = fsspec.open_files(\"simplecache::s3://\" + filename, s3={'anon': True})\n",
+    "fs_files = [FSFile(open_file) for open_file in the_files]\n",
+    "\n",
+    "# Pass S3 file objects to Satpy and read them with the 'abi_l1b' reader\n",
+    "scn = Scene(filenames=fs_files, reader='abi_l1b')\n",
+    "\n",
+    "# Load all 16 ABI channels\n",
+    "scn.load(['C01', 'C02', 'C03', 'C04', 'C05', 'C06', 'C07', 'C08',\n",
+    "          'C09', 'C10', 'C11', 'C12', 'C13', 'C14', 'C15', 'C16'])\n",
+    "\n",
+    "# Save each channel to a PNG image\n",
+    "scn.save_datasets(filename='{name}.png')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we can use the ImageMagick command `montage` to join all the images together.\n",
+    "\n",
+    "Note: Some ImageMagick installations may be limited and unable to process every image in the montage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!montage C??.png -tile 4x4 -geometry 128x128+4+4 -background black montage_abi.png"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Image\n",
+    "Image(filename='montage_abi.png') "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Local Files\n",
+    "\n",
+    "Alternatively, if you have ABI L1b files on your local machine already, you can point Satpy to those directly:"
    ]
   },
   {
@@ -18,13 +95,17 @@
     "import glob\n",
     "from satpy.scene import Scene\n",
     "\n",
+    "# Access local ABI L1b NetCDF files\n",
     "scn = Scene(\n",
-    "    filenames=glob.glob(\"/path/to/the/Goes-16/data/*RadF*\"),\n",
+    "    filenames=glob.glob(\"/path/to/the/GOES-16/data/*RadF*.nc\"),\n",
     "    reader='abi_l1b'\n",
     ")\n",
     "\n",
-    "channels = ['C{channel:02d}'.format(channel=chn) for chn in range(1, 17)]\n",
-    "scn.load(channels)\n",
+    "# Load all 16 ABI channels\n",
+    "scn.load(['C01', 'C02', 'C03', 'C04', 'C05', 'C06', 'C07', 'C08',\n",
+    "          'C09', 'C10', 'C11', 'C12', 'C13', 'C14', 'C15', 'C16'])\n",
+    "\n",
+    "# Save each channel to a PNG image\n",
     "scn.save_datasets(filename='{name}.png')"
    ]
   },
@@ -32,23 +113,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then we can use the ImageMagick command `montage` to join all the images together."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!montage C??.png -geometry 512x512+4+4 -background black montage_abi.jpg"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<img src=\"montage_abi.jpg\">"
+    "# Additional Information\n",
+    "\n",
+    "1. To avoid S3 files being cached on your local system, modify the `fsspec.open_files` line to say:\n",
+    "\n",
+    "   ```\n",
+    "   the_files = fsspec.open_files(\"s3://\" + filename, anon=True)\n",
+    "   ```\n",
+    "   \n",
+    "   Note however that this means that any repeated access to file content will take longer and will increase the overall processing time.\n",
+    "   \n",
+    "2. To save images in the GeoTIFF format, you can call `scn.save_datasets()` without any arguments as geotiffs are the default."
    ]
   }
  ],
@@ -68,7 +143,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This updates two examples:

1. GOES-16 Mosaic: Use S3 and provide more information about other options.
2. GOES-16 ABI True Color Animation: Use `MultiScene.from_files`.

I tried to have examples of using dask and S3 for the animation example but ran into two issues. S3 alone results in a broken pipe to ffmpeg. I'm not sure how this is possible, but I have a feeling it is a timeout of sorts (even though imageio-ffmpeg is not supposed to set one). The other issue is when combining FSFiles with dask multiprocess (create a `Client` object and save an animation) there is a serialization error somewhere. I don't have time to investigate this further.