### PR TITLE
Fix bug in OLCI L1 example

### DIFF
--- a/satpy/OLCI L1B.ipynb
+++ b/satpy/OLCI L1B.ipynb
@@ -45,7 +45,7 @@
     "                               start_time=datetime(2018, 8, 29, 8, 26),\n",
     "                               end_time=datetime(2018, 8, 29, 8, 27),\n",
     "                               base_dir=\"/data/temp/Martin.Raspaud/s3\",\n",
-    "                               reader='nc_olci_l1b')\n",
+    "                               reader='olci_l1b')\n",
     "\n",
     "scn = Scene(filenames=files)"
    ]


### PR DESCRIPTION
The OLCI example uses the wrong reader name: It has `nc_olci_l1b` rather than `olci_l1b`. This PR fixes the bug.